### PR TITLE
Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,4 +12,9 @@ set_target_properties(tegra_drv_video PROPERTIES CXX_STANDARD_REQUIRED ON)
 target_link_libraries(tegra_drv_video ${DRM_LIBRARIES})
 target_include_directories(tegra_drv_video PUBLIC ${DRM_INCLUDE_DIRS})
 
-install(TARGETS tegra_drv_video LIBRARY DESTINATION lib)
+if("${LIBVA_DRIVERS_PATH}" STREQUAL "")
+    set(LIBVA_DRIVERS_PATH "lib${LIB_SUFFIX}/dri/")
+endif()
+message(STATUS "LIBVA_DRIVERS_PATH = ${LIBVA_DRIVERS_PATH}")
+
+install(TARGETS tegra_drv_video LIBRARY DESTINATION ${LIBVA_DRIVERS_PATH})


### PR DESCRIPTION
Various fixes for building vaapi-tegra-driver on modern libva (2.9.0+).

Only tried with upstream kernel and jetson-tx1 for now on fedora 33 (and using wayland as tegra might needs xorg patches from master to work with nouveau, last I've tried...)

$ vainfo 
error: can't connect to X server!
libva info: VA-API version 1.9.0
libva info: User environment variable requested driver 'tegra'
libva info: Trying to open /usr/lib64/dri/tegra_drv_video.so
libva info: Found init function __vaDriverInit_1_0
libva info: va_openDriver() returns 0
vainfo: VA-API version: 1.9 (libva 2.9.0)
vainfo: Driver version: Tegra Host1x driver
vainfo: Supported profile and entrypoints


With that said: using putsurface failed with:

LD_PRELOAD=/usr/lib64/libva-wayland.so.2 putsurface
Create window0 for thread0
libva info: VA-API version 1.9.0
libva info: User environment variable requested driver 'tegra'
libva info: Trying to open /usr/lib64/dri/tegra_drv_video.so
libva info: Found init function __vaDriverInit_1_0
libva info: va_openDriver() returns 0
GEM create failed: Invalid argument
main:vaCreateSurfaces (644) failed,exi

So I guess the "Switch to va_dri_get,swap etc" patch is incorrect...
